### PR TITLE
Fixing the synchronisation issue when the process stoped during blocksync

### DIFF
--- a/counterparty2mysql.php
+++ b/counterparty2mysql.php
@@ -239,10 +239,7 @@ while($block <= $current){
             // print $sql;
             $results = $mysqli->query($sql);
             if($results){
-                // Only create the record if it does not already exist
-
-                //on duplicate key statement
-
+                //on duplicate key statement will update the row if exists already
                 if($results->num_rows==0){
                     $sql = "INSERT INTO {$table} (" . implode(",", $fields)  . ") values ('" . implode("', '", $values) . "') ON DUPLICATE KEY UPDATE $sqlUpdate";
                     $results = $mysqli->query($sql);

--- a/counterparty2mysql.php
+++ b/counterparty2mysql.php
@@ -224,15 +224,27 @@ while($block <= $current){
             $skip = false;
             // Check if this record already exists
             $sql = "SELECT * FROM {$table} WHERE";
-            foreach($fields as $index => $field)
+
+            $sqlUpdate = '';
+            foreach($fields as $index => $field){
                 $sql .= " {$field}='{$values[$index]}' AND";
+
+                //building potential update statement
+                $sqlUpdate .= " {$field}='{$values[$index]}' AND";
+            }
+
             $sql = rtrim($sql, " AND");
+            $sqlUpdate = rtrim($sqlUpdate, " AND");
+
             // print $sql;
             $results = $mysqli->query($sql);
             if($results){
                 // Only create the record if it does not already exist
+
+                //on duplicate key statement
+
                 if($results->num_rows==0){
-                    $sql = "INSERT INTO {$table} (" . implode(",", $fields)  . ") values ('" . implode("', '", $values) . "')";
+                    $sql = "INSERT INTO {$table} (" . implode(",", $fields)  . ") values ('" . implode("', '", $values) . "') ON DUPLICATE KEY UPDATE $sqlUpdate";
                     $results = $mysqli->query($sql);
                     if(!$results && !$skip)
                         byeLog('Error while trying to create record in ' . $table . ' : ' . $sql);


### PR DESCRIPTION
Previously restarting the synchronisation process after a failure would raise error on the last block if it was not completely parsed. (Duplicate insert error)

The fix should be reviewed since i'm not familiar with synchronisation feature. Could it mess up with the database indexes ? I should not as I guess the update statement should be equal to to previously inserted statement but I'm not sure,  additional review would be good to be on the safe side.

(Shaban)